### PR TITLE
Adds byte order mark (BOM)

### DIFF
--- a/src/tableHTMLExport.js
+++ b/src/tableHTMLExport.js
@@ -37,7 +37,8 @@ THE SOFTWARE.*/
                 consoleLog: false,
                 trimContent: true,
                 quoteFields: true,
-                filename: 'tableHTMLExport.csv'
+                filename: 'tableHTMLExport.csv',
+                utf8BOM: true
             };
             var options = $.extend(defaults, options);
 
@@ -117,6 +118,10 @@ THE SOFTWARE.*/
              */
             function toCsv(table){
                 var output = "";
+                
+                if (options.utf8BOM === true) {                
+                    output += '\ufeff';
+                }
 
                 var rows = table.find('tr').not(options.ignoreRows);
 


### PR DESCRIPTION
Adds UTF8 byte order mark (BOM) to the CSV export to avoid character set confusion in Excel when opening the CSV. Excel normally expects ISO-8859-1 or some other more regional encoding for CSV files, and this instructs Excel that the CSV file uses UTF-8.